### PR TITLE
Add workflow to sync compose assets before VPS deployment

### DIFF
--- a/.github/workflows/deploy-to-vps.yml
+++ b/.github/workflows/deploy-to-vps.yml
@@ -23,6 +23,13 @@ on:
       COMPOSE_PATH:
         required: true
         type: string
+      RUN_COMPOSE_PULL:
+        description: >-
+          When true, execute `docker compose pull` on the VPS before running
+          `docker compose up -d` to refresh service images.
+        required: false
+        default: false
+        type: boolean
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -44,6 +51,7 @@ jobs:
           GHCR_ORG="$3"
           IMAGE_NAME="$4"
           COMPOSE_PATH="$5"
+          RUN_COMPOSE_PULL="$6"
           
           echo "===== Starting deployment process ====="
           echo "Image: ghcr.io/$GHCR_ORG/$IMAGE_NAME:latest"
@@ -71,8 +79,13 @@ jobs:
           # Pull with verbose output
           docker pull ghcr.io/$GHCR_ORG/$IMAGE_NAME:latest
           
+          if [ "$RUN_COMPOSE_PULL" = "true" ]; then
+            echo "===== Refreshing services with docker compose pull ====="
+            docker compose -f "$COMPOSE_PATH" pull
+          fi
+
           echo "===== Deploying with Docker Compose ====="
-          docker compose -f $COMPOSE_PATH up -d
+          docker compose -f "$COMPOSE_PATH" up -d
           
           echo "===== Cleaning up ====="
           docker image prune -f
@@ -88,7 +101,7 @@ jobs:
           scp -o StrictHostKeyChecking=no deploy.sh ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:/tmp/deploy.sh
           
           # Run the script with secrets as arguments
-          ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} "bash /tmp/deploy.sh '${{ secrets.GHCR_TOKEN }}' '${{ secrets.GHCR_USERNAME }}' '${{ secrets.GHCR_ORG }}' '${{ inputs.IMAGE_NAME }}' '${{ inputs.COMPOSE_PATH }}'"
+          ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} "bash /tmp/deploy.sh '${{ secrets.GHCR_TOKEN }}' '${{ secrets.GHCR_USERNAME }}' '${{ secrets.GHCR_ORG }}' '${{ inputs.IMAGE_NAME }}' '${{ inputs.COMPOSE_PATH }}' '${{ inputs.RUN_COMPOSE_PULL }}'"
           
           # Clean up
           ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} "rm -f /tmp/deploy.sh"

--- a/.github/workflows/sync-compose-to-vps.yml
+++ b/.github/workflows/sync-compose-to-vps.yml
@@ -1,0 +1,122 @@
+name: Sync Compose Assets to VPS
+
+on:
+  workflow_call:
+    inputs:
+      compose-path:
+        description: >-
+          Path to the Docker Compose file or directory to upload relative to the
+          repository root.
+        required: true
+        type: string
+      remote-path:
+        description: >-
+          Absolute path on the VPS where the primary docker-compose file should
+          reside (e.g. /opt/my-app/docker-compose.yml).
+        required: true
+        type: string
+    secrets:
+      SSH_PRIVATE_KEY:
+        required: true
+      VPS_HOST:
+        required: true
+      VPS_USER:
+        required: true
+    outputs:
+      remote-compose-path:
+        description: Absolute path to the docker-compose file on the VPS.
+        value: ${{ jobs.sync.outputs.remote-compose-path }}
+      remote-directory:
+        description: Directory on the VPS containing the synced assets.
+        value: ${{ jobs.sync.outputs.remote-directory }}
+
+jobs:
+  sync:
+    name: Sync compose assets
+    runs-on: ubuntu-latest
+    outputs:
+      remote-compose-path: ${{ steps.prepare.outputs.remote_path }}
+      remote-directory: ${{ steps.prepare.outputs.remote_dir }}
+    steps:
+      - name: Checkout caller repository
+        uses: actions/checkout@v4
+
+      - name: Collect compose assets
+        id: prepare
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          target="${{ inputs.compose-path }}"
+          if [ ! -e "$target" ]; then
+            echo "The provided compose-path '$target' does not exist." >&2
+            exit 1
+          fi
+
+          workspace="${GITHUB_WORKSPACE}/.sync-compose"
+          rm -rf "$workspace"
+          mkdir -p "$workspace"
+
+          if [ -d "$target" ]; then
+            bundle_name="compose-bundle.tar.gz"
+            tar -C "$target" -czf "$workspace/$bundle_name" .
+            echo "is_dir=true" >> "$GITHUB_OUTPUT"
+          elif [ -f "$target" ]; then
+            bundle_name="$(basename "$target")"
+            cp "$target" "$workspace/$bundle_name"
+            echo "is_dir=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "The compose-path must be a file or directory." >&2
+            exit 1
+          fi
+
+          remote_path="${{ inputs.remote-path }}"
+          if [ -z "$remote_path" ]; then
+            echo "The remote-path input cannot be empty." >&2
+            exit 1
+          fi
+          remote_dir="$(dirname "$remote_path")"
+
+          echo "bundle=$workspace/$bundle_name" >> "$GITHUB_OUTPUT"
+          echo "bundle_name=$bundle_name" >> "$GITHUB_OUTPUT"
+          echo "remote_path=$remote_path" >> "$GITHUB_OUTPUT"
+          echo "remote_dir=$remote_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Configure SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Add VPS host to known_hosts
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H "${{ secrets.VPS_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Ensure remote directory exists
+        run: |
+          ssh "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" \
+            "mkdir -p '${{ steps.prepare.outputs.remote_dir }}'"
+
+      - name: Upload compose file
+        if: steps.prepare.outputs.is_dir == 'false'
+        run: |
+          scp "${{ steps.prepare.outputs.bundle }}" \
+            "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:${{ steps.prepare.outputs.remote_path }}"
+
+      - name: Upload compose bundle
+        if: steps.prepare.outputs.is_dir == 'true'
+        run: |
+          scp "${{ steps.prepare.outputs.bundle }}" \
+            "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:${{ steps.prepare.outputs.remote_dir }}/${{ steps.prepare.outputs.bundle_name }}"
+
+      - name: Unpack compose bundle on VPS
+        if: steps.prepare.outputs.is_dir == 'true'
+        run: |
+          ssh "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" \
+            "cd '${{ steps.prepare.outputs.remote_dir }}' && \
+             tar -xzf '${{ steps.prepare.outputs.bundle_name }}' && \
+             rm -f '${{ steps.prepare.outputs.bundle_name }}'"
+
+      - name: Compose assets synced
+        run: |
+          echo "Compose assets are available at: ${{ steps.prepare.outputs.remote_path }}"


### PR DESCRIPTION
## Summary
- add a reusable workflow that syncs docker compose assets to a VPS over SSH
- document the workflow and show how to chain it before the existing deploy template
- extend the deploy-to-vps workflow with an optional docker compose pull step

## Testing
- not run (workflow definitions only)


------
https://chatgpt.com/codex/tasks/task_e_68d0a9a4a704832b8a1da70a766b2c28