### PR TITLE
Restore sync-compose outputs

### DIFF
--- a/.github/workflows/sync-compose-to-vps.yml
+++ b/.github/workflows/sync-compose-to-vps.yml
@@ -15,6 +15,13 @@ on:
           reside (e.g. /opt/my-app/docker-compose.yml).
         required: true
         type: string
+    outputs:
+      remote-compose-path:
+        description: Absolute path on the VPS to the uploaded compose file.
+        value: ${{ jobs.sync.outputs.remote-compose-path }}
+      remote-directory:
+        description: Directory on the VPS where compose assets are stored.
+        value: ${{ jobs.sync.outputs.remote-directory }}
     secrets:
       SSH_PRIVATE_KEY:
         required: true
@@ -26,6 +33,9 @@ jobs:
   sync:
     name: Sync compose assets
     runs-on: ubuntu-latest
+    outputs:
+      remote-compose-path: ${{ steps.prepare.outputs.remote_path }}
+      remote-directory: ${{ steps.prepare.outputs.remote_dir }}
     steps:
       - name: Checkout caller repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- restore workflow_call outputs for the sync-compose workflow so downstream jobs can consume the remote compose metadata
- publish job-level outputs that proxy the prepare step values without exposing them in the logs

## Testing
- not run (not applicable in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68d2c1522d5c832bac73c3eda59cda90